### PR TITLE
Add Community Apps & Modules section

### DIFF
--- a/content/community-apps.md
+++ b/content/community-apps.md
@@ -1,0 +1,20 @@
+---
+title: Community Apps & Modules
+---
+
+# Community Apps & Modules
+
+Apps and modules built on Logos by the community, outside of core Logos development.
+
+**8 apps discovered** — _Last updated: 2026-03-25_
+
+| Name | Repo | Author | Description | Last Commit | First Discovered |
+|------|------|--------|-------------|-------------|-----------------|
+| logos-notes | [xAlisher/logos-notes](https://github.com/xAlisher/logos-notes) | xAlisher | Encrypted local-first notes for Logos Basecamp, hardware-secured via Status Keycard | 2026-03-19 | 2026-03-25 |
+| keycard-basecamp | [xAlisher/keycard-basecamp](https://github.com/xAlisher/keycard-basecamp) | xAlisher | Standalone Keycard smartcard auth module for Basecamp apps | 2026-03-24 | 2026-03-25 |
+| logos-legos | [corpetty/logos-legos](https://github.com/corpetty/logos-legos) | corpetty | Visual workflow builder (n8n-style) for composing Logos protocol operations | 2026-03-18 | 2026-03-25 |
+| logos-workflow-registry | [corpetty/logos-workflow-registry](https://github.com/corpetty/logos-workflow-registry) | corpetty | Module introspection layer for Logos Legos v2 | 2026-03-20 | 2026-03-25 |
+| logos-workflow-canvas | [corpetty/logos-workflow-canvas](https://github.com/corpetty/logos-workflow-canvas) | corpetty | Qt/QML visual editor module for Logos Legos v2 | 2026-03-20 | 2026-03-25 |
+| logos-workflow-engine | [corpetty/logos-workflow-engine](https://github.com/corpetty/logos-workflow-engine) | corpetty | Headless DAG workflow executor Logos module | 2026-03-20 | 2026-03-25 |
+| logos-workflow-scheduler | [corpetty/logos-workflow-scheduler](https://github.com/corpetty/logos-workflow-scheduler) | corpetty | Cron/webhook trigger manager Logos module | 2026-03-20 | 2026-03-25 |
+| logos-storage-app-skeleton | [logos-storage/logos-storage-app-skeleton](https://github.com/logos-storage/logos-storage-app-skeleton) | logos-storage | CLI skeleton companion for the Logos Storage API tutorial | 2026-03-24 | 2026-03-25 |

--- a/content/community-apps.md
+++ b/content/community-apps.md
@@ -6,7 +6,7 @@ title: Community Apps & Modules
 
 Apps and modules built on Logos by the community, outside of core Logos development.
 
-**8 apps discovered** — _Last updated: 2026-03-25_
+**9 apps discovered** — _Last updated: 2026-03-25_
 
 | Name | Repo | Author | Description | Last Commit | First Discovered |
 |------|------|--------|-------------|-------------|-----------------|
@@ -18,3 +18,4 @@ Apps and modules built on Logos by the community, outside of core Logos developm
 | logos-workflow-engine | [corpetty/logos-workflow-engine](https://github.com/corpetty/logos-workflow-engine) | corpetty | Headless DAG workflow executor Logos module | 2026-03-20 | 2026-03-25 |
 | logos-workflow-scheduler | [corpetty/logos-workflow-scheduler](https://github.com/corpetty/logos-workflow-scheduler) | corpetty | Cron/webhook trigger manager Logos module | 2026-03-20 | 2026-03-25 |
 | logos-storage-app-skeleton | [logos-storage/logos-storage-app-skeleton](https://github.com/logos-storage/logos-storage-app-skeleton) | logos-storage | CLI skeleton companion for the Logos Storage API tutorial | 2026-03-24 | 2026-03-25 |
+| logos-video-hotspot | [marclawclaw/logos-video-hotspot](https://github.com/marclawclaw/logos-video-hotspot) | marclawclaw (fryorcraken) | Qt/CLI app for a local video streaming hotspot using Logos storage and delivery modules, with Qt GUI for managing streams | 2026-03-23 | 2026-03-25 |


### PR DESCRIPTION
Adds a new Community Apps section to the homepage listing third-party apps and modules built on Logos. Discovered via GitHub code search on 2026-03-25. cc @logos-co/eco-dev-eng